### PR TITLE
Update for the 0.11.0 version correct url

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -103,7 +103,7 @@
   <script src="/js/vendor/superagent.js"></script>
 
   <script src="https://media.twiliocdn.com/sdk/js/common/releases/0.1.5/twilio-common.js"></script>
-  <script src="https://stage.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.js"></script>
+  <script src="https://media.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.js"></script>
 
   <script src="https://apis.google.com/js/platform.js" async defer></script>
   <script type="text/javascript" src="/js/md5.js"></script>


### PR DESCRIPTION
The following urls gives me an error:
https://stage.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.js

Looking at Twilio control panel, it's pointing me to 
https://media.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.js

The second urls works fine.