### PR TITLE
Updates JS SDK locations.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -102,8 +102,8 @@
   <script src="/js/vendor/fingerprint2.js"></script>
   <script src="/js/vendor/superagent.js"></script>
 
-  <script src="https://media.twiliocdn.com/sdk/js/common/releases/0.1.5/twilio-common.js"></script>
-  <script src="https://stage.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.js"></script>
+  <script src="https://media.twiliocdn.com/sdk/js/common/v0.1/twilio-common.min.js"></script>
+  <script src="https://media.twiliocdn.com/sdk/js/chat/v0.11/twilio-chat.min.js"></script>
 
   <script src="https://apis.google.com/js/platform.js" async defer></script>
   <script type="text/javascript" src="/js/md5.js"></script>


### PR DESCRIPTION
One of the files was using stage.twiliocdn.com which wasn't loading.
Updated to the script tags documented here: https://www.twilio.com/docs/api/chat/sdks.